### PR TITLE
Add actions autobuild

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,34 @@
+name: Android CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: set up JDK 11
+      uses: actions/setup-java@v2
+      with:
+        java-version: '11'
+        distribution: 'adopt'
+        cache: gradle
+    - name: Install proper NDK
+      run: echo "y" | sudo ${ANDROID_HOME}/tools/bin/sdkmanager --install "ndk;21.3.6528147" --sdk_root=${ANDROID_SDK_ROOT}
+    
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+    - name: Build with Gradle
+      run: ./gradlew build -x lint -x lintVitalRelease
+      
+    - uses: actions/upload-artifact@v2
+      if: failure()
+      with:
+        name: error logs
+        path: /home/runner/work/FTC-BASE-CODE/FTC-BASE-CODE/TeamCode/build/reports


### PR DESCRIPTION
This is literally copied from the functional action in our 2021 repo
Once merged I’m going to set up merge protection so that code that wont build can’t be merged to main